### PR TITLE
Cache small number object in memory

### DIFF
--- a/sig/generated/wardite/value.rbs
+++ b/sig/generated/wardite/value.rbs
@@ -32,6 +32,12 @@ module Wardite
     # when we want to access signed value, it'd be done via #value_s
     attr_accessor value: Integer
 
+    @@i32_object_pool: Hash[Integer, I32]
+
+    # @rbs value: Integer
+    # @rbs return: I32
+    def self.cached_or_initialize: (Integer value) -> I32
+
     # @rbs value: Integer
     def initialize: (?Integer value) -> untyped
 
@@ -118,6 +124,9 @@ module Wardite
     I64_MAX: Integer
 
     attr_accessor value: Integer
+
+    # @rbs value: Integer
+    def initialize: (?Integer value) -> untyped
 
     # @rbs str: String
     # @rbs size: Integer|nil


### PR DESCRIPTION
before:

```
bundle exec ruby --yjit tmp/grayscale-cmd.rb --wasm-file  --source  --dest     7.03s user 0.06s system 94% cpu 7.518 total
```

after(best case):

```
bundle exec ruby --yjit tmp/grayscale-cmd.rb --wasm-file  --source  --dest     6.77s user 0.06s system 99% cpu 6.870 total
```